### PR TITLE
Opening and closing clues work between players, money values added, greyed out boxes, get room information

### DIFF
--- a/client/app/game-board/game-board.module.css
+++ b/client/app/game-board/game-board.module.css
@@ -132,3 +132,7 @@
   padding: 5px 15px;
   cursor: pointer;
 }
+.button.disabled {
+  background-color: grey;
+  cursor: not-allowed;
+}

--- a/client/app/game-board/page.js
+++ b/client/app/game-board/page.js
@@ -10,9 +10,22 @@ export default function GameBoardPage() {
   const [answerFeedback, setAnswerFeedback] = useState("");
   const [expandingBox, setExpandingBox] = useState(null);
   const questionRef = useRef(null);
-  const socket = useSocket();
 
   const clickMe = (question, value) => {
+    setExpandingBox({ question, value });
+
+    window.sendMessage({
+      "action": "clickQuestion",
+      "content": question,
+    });
+    
+    setTimeout(() => {
+      setSelectedQuestion(question);
+    }, 500);
+    setAnswerFeedback("");
+  };
+
+  const socketClickMe = (question, value) => {
     setExpandingBox({ question, value });
     setTimeout(() => {
       setSelectedQuestion(question);
@@ -22,10 +35,35 @@ export default function GameBoardPage() {
 
   const closeQuestion = () => {
     setSelectedQuestion(null);
+    window.sendMessage({
+      "action": "closeQuestion",
+      "content": "",
+    });
     setTimeout(() => {
       setExpandingBox(null);
     }, 500);
   };
+
+  const socketCloseQuestion = () => {
+    setSelectedQuestion(null);
+    setTimeout(() => {
+      setExpandingBox(null);
+    }, 500);
+  };
+
+  const handleServerMessage = (message) => {
+    const action = message["action"]
+    if (action == "clickQuestion") {
+      const question = message["content"];
+      console.log(question, question.value)
+      socketClickMe(question, question.value);
+    }
+    if (action == "closeQuestion") {
+      socketCloseQuestion();
+    }
+  };
+
+  const socket = useSocket(handleServerMessage);
 
   const renderCategories = () => {
     if (!Array.isArray(selectedData)) {

--- a/client/app/game-search-page/page.js
+++ b/client/app/game-search-page/page.js
@@ -11,7 +11,10 @@ export default function GameSearchingPage() {
   const selectedData = useSelector((state) => state.selectedData.value);
   const dispatch = useDispatch();
   const router = useRouter();
-  const socket = useSocket();
+
+  const handleServerMessage = (message) => {};
+
+  const socket = useSocket(handleServerMessage);
 
   useEffect(() => {
     fetch(process.env.NEXT_PUBLIC_SERVER_URL + "/api/jeopardy")

--- a/client/app/socketClient.js
+++ b/client/app/socketClient.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 import { io } from "socket.io-client";
 
-export const useSocket = () => {
+export const useSocket = (onMessageReceivedCallback) => {
   const socketRef = useRef(null);
   const [roomKey, setRoomKey] = useState("");
   const [socketDisplayName, setSocketDisplayName] = useState("");
@@ -48,7 +48,7 @@ export const useSocket = () => {
   }, []);
 
   useEffect(() => {
-    const socketInstance = io("https://team2-server.onrender.com/");  // Ensure the URL is correct (e.g. localhost for testing)
+    const socketInstance = io("http://localhost:8080/");  // Ensure the URL is correct (e.g. localhost for testing)
     socketRef.current = socketInstance;
 
     console.log(
@@ -68,7 +68,10 @@ export const useSocket = () => {
     });
 
     socketInstance.on("receivedCustomMessage", (message) => {
-      console.log("[From Server: Custom message received] -", message);
+      console.log("[From Server: Custom message received] -", message["action"], message["content"]);
+      if (onMessageReceivedCallback) {
+        onMessageReceivedCallback(message); // Trigger the callback when a message is received
+      }
     });
 
     // Receive rooms object from server and we opt to store it 

--- a/client/app/socketClient.js
+++ b/client/app/socketClient.js
@@ -31,7 +31,7 @@ export const useSocket = (onMessageReceivedCallback) => {
 
         if (storedDisplayName) {
           setSocketDisplayName(storedDisplayName);
-          socketDisplayNameRef.current = storedDisplayName; 
+          socketDisplayNameRef.current = storedDisplayName;
           console.log(
             `[Client-side Acknowledgement] Retrieved display name from localStorage: ${storedDisplayName}`
           );
@@ -48,7 +48,7 @@ export const useSocket = (onMessageReceivedCallback) => {
   }, []);
 
   useEffect(() => {
-    const socketInstance = io("http://localhost:8080/");  // Ensure the URL is correct (e.g. localhost for testing)
+    const socketInstance = io("http://localhost:8080/"); // Ensure the URL is correct (e.g. localhost for testing)
     socketRef.current = socketInstance;
 
     console.log(
@@ -68,15 +68,19 @@ export const useSocket = (onMessageReceivedCallback) => {
     });
 
     socketInstance.on("receivedCustomMessage", (message) => {
-      console.log("[From Server: Custom message received] -", message["action"], message["content"]);
+      console.log(
+        "[From Server: Custom message received] -",
+        message["action"],
+        message["content"]
+      );
       if (onMessageReceivedCallback) {
         onMessageReceivedCallback(message); // Trigger the callback when a message is received
       }
     });
 
-    // Receive rooms object from server and we opt to store it 
+    // Receive rooms object from server and we opt to store it
     socketInstance.on("receiveRooms", (rooms) => {
-      setRoomsData(rooms); 
+      setRoomsData(rooms);
       console.log("[From Server: Rooms data received from server] -", rooms);
     });
 
@@ -121,10 +125,23 @@ export const useSocket = (onMessageReceivedCallback) => {
       };
     } else {
       window.getRooms = () => {
-        console.log(
-          "[Client-side Acknowledgement] Socket is not initialized."
-        );
+        console.log("[Client-side Acknowledgement] Socket is not initialized.");
       };
+    }
+  }, []);
+
+  useEffect(() => {
+    if (socketRef.current) {
+      window.getPlayersInRoom = () => {
+        console.log(
+          "[Client-side Acknowledgement] Requesting players in the current room..."
+        );
+        socketRef.current.emit("getPlayersInRoom");
+      };
+
+      socketRef.current.on("playersInRoom", (players) => {
+        console.log("[From Server: Players in room] -", players);
+      });
     }
   }, []);
 
@@ -143,9 +160,7 @@ export const useSocket = (onMessageReceivedCallback) => {
         if (socketDisplayNameRef.current) {
           setRoomKey(key);
           localStorage.setItem("roomKey", key);
-          console.log(
-            `[Client-side Acknowledgement] Room key set to: ${key}`
-          );
+          console.log(`[Client-side Acknowledgement] Room key set to: ${key}`);
         } else {
           console.log(
             "[Client-side Acknowledgement] Cannot set room key before setting display name."

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.7",
-        "firebase": "^10.14.0",
+        "firebase": "^10.14.1",
         "next": "^14.2.14",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/client/package.json
+++ b/client/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "firebase": "^10.14.0",
     "@reduxjs/toolkit": "^2.2.7",
+    "firebase": "^10.14.1",
     "next": "^14.2.14",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/server/socketServer.js
+++ b/server/socketServer.js
@@ -8,65 +8,65 @@ module.exports = function (server) {
     });
     
     const rooms = {
-        "": [], // Default room for users without a room
+        "": {}, // Default room for users without a room, stores players and their money
     };
     
     io.on("connection", (socket) => {
         let currentDisplayName = "";
-        let currentRoomKey = "";
+        let currentRoomKey = ""; // Initially, the user is in the default room
 
         console.log("New connection established:", socket.id);
 
+        // Event listener for setting the display name
         socket.on("displayName", (displayName) => {
             currentDisplayName = displayName;
             console.log(`Display name received: ${currentDisplayName}`);
 
-            // Add to the default room if no room key is assigned yet
-            if (!currentRoomKey) {
-                rooms[""].push(currentDisplayName);
-            } else {
-                // Add the user to their room if they have one
-                if (!rooms[currentRoomKey]) {
-                    rooms[currentRoomKey] = [];
-                }
-                rooms[currentRoomKey].push(currentDisplayName);
-            }
+            // Add player to the default room with a starting balance of 0
+            rooms[""][currentDisplayName] = 0; // Default starting money in the default room
+            currentRoomKey = ""; // By default, user is in the default room
+            
+            // there's a bug here, they'll always be in the default room for some reason
+            // will fix later
 
+            console.log(`User "${currentDisplayName}" added to the default room with 0 balance.`);
             console.log("Updated rooms object after displayName set:", rooms);
         });
 
+        // Event listener for setting the roomKey
         socket.on("roomKey", (roomKey) => {
             console.log(`Room key received: ${roomKey}, Current Display Name: ${currentDisplayName}`);
 
-            // Check if displayName is set; this validation is also done client side, so it shouldn't come to this
             if (!currentDisplayName) {
                 console.log("Display name not set. Prompting client to set display name.");
                 socket.emit("promptDisplayName", "Please set your display name before joining a room.");
                 return;
             }
 
-            // Remove the user from the default room (also a catch-all for when a user rejoins)
-            if (rooms[""].includes(currentDisplayName)) {
-                rooms[""] = rooms[""].filter((name) => name !== currentDisplayName);
-                console.log(`User "${currentDisplayName}" removed from default room.`);
+            // Check if the player is in the default room and remove them
+            // there's a bug here, they won't get removed for some reason will fix later
+            if (currentRoomKey === "" && rooms[""][currentDisplayName]) {
+                delete rooms[""][currentDisplayName]; // Remove the player from the default room
+                socket.leave(""); // Leave the default room on the server-side
+                console.log(`User "${currentDisplayName}" removed from the default room.`);
             }
 
-            // Remove the user from any previously assigned room
-            if (currentRoomKey) {
-                rooms[currentRoomKey] = rooms[currentRoomKey].filter((name) => name !== currentDisplayName);
-                // Make the socket leave the previous room
-                socket.leave(currentRoomKey);
+            // Check if the player is in another room and remove them from that room
+            if (currentRoomKey && currentRoomKey !== roomKey && rooms[currentRoomKey]) {
+                delete rooms[currentRoomKey][currentDisplayName]; // Remove from the previous room
+                socket.leave(currentRoomKey); // Leave the previous room
+                console.log(`User "${currentDisplayName}" removed from room "${currentRoomKey}".`);
             }
 
-            // Assign the user to the new room
+            // Update the current room key to the new room
             currentRoomKey = roomKey;
-            if (!rooms[roomKey]) {
-                rooms[roomKey] = [];
-            }
-            rooms[roomKey].push(currentDisplayName);
 
-            // actual joining of room here
-            socket.join(roomKey);
+            // Add the player to the new room
+            if (!rooms[roomKey]) {
+                rooms[roomKey] = {}; // Create the room if it doesn't exist
+            }
+            rooms[roomKey][currentDisplayName] = 0; // Default starting money in the new room
+            socket.join(roomKey); // Join the new room
 
             console.log(`User "${currentDisplayName}" joined room "${roomKey}"`);
             console.log("Updated rooms object after roomKey set:", rooms);
@@ -75,25 +75,44 @@ module.exports = function (server) {
             socket.emit("confirmReceivedRoom", `You joined room: ${roomKey}`);
         });
 
+        // Event listener for custom messages
         socket.on("customMessage", (message) => {
-            // the message object here is different than the one in the client as seen below: it contains displayName and roomKey
             console.log(`Custom message from ${message["displayName"]}: ${message["message"]}, ${message["roomKey"]}`);
-            // Emit the message to all sockets in the room except the sender (note use io.to().emit() if you want to everyone in room)
             socket.to(message["roomKey"]).emit("receivedCustomMessage", message["message"]);
         });
 
+        // Event listener for requesting room data
         socket.on("getRooms", () => {
-            console.log(`Rooms data requested by ${currentDisplayName}`);
             socket.emit("receiveRooms", rooms);  // Send rooms object back to the client
         });
 
-        socket.on("disconnect", () => {
-            if (currentRoomKey) {
-                rooms[currentRoomKey] = rooms[currentRoomKey].filter((name) => name !== currentDisplayName);
-                // sockets leaves the room upon disconnection
-                socket.leave(currentRoomKey);
+        // Event listener for setting money amounts
+        socket.on("setMoneyAmount", ({ displayName, roomKey, money }) => {
+            console.log(`Money update received: ${displayName} in room ${roomKey} now has ${money}`);
+        
+            // Ensure the displayName and roomKey are valid
+            if (displayName && roomKey) {
+                if (!rooms[roomKey]) {
+                    rooms[roomKey] = {}; // Create the room if it doesn't exist
+                }
+        
+                if (rooms[roomKey][displayName] !== undefined) {
+                    rooms[roomKey][displayName] = money; // Update the player's money
+                    console.log(`Updated money for ${displayName} in room ${roomKey}: ${money}`);
+                } else {
+                    console.log(`Player ${displayName} is not in room ${roomKey}`);
+                }
             }
-            console.log(`User ${currentDisplayName} disconnected from room "${currentRoomKey}"`);
+        });
+        
+        // Event listener for handling disconnects
+        socket.on("disconnect", () => {
+            // Remove the user from their current room when they disconnect
+            if (currentRoomKey && rooms[currentRoomKey]) {
+                delete rooms[currentRoomKey][currentDisplayName]; // Remove player from the room object
+                socket.leave(currentRoomKey);
+                console.log(`User ${currentDisplayName} disconnected and removed from room "${currentRoomKey}".`);
+            }
             console.log("Updated rooms object after disconnect:", rooms);
         });
     });

--- a/server/socketServer.js
+++ b/server/socketServer.js
@@ -76,6 +76,7 @@ module.exports = function (server) {
         });
 
         socket.on("customMessage", (message) => {
+            // the message object here is different than the one in the client as seen below: it contains displayName and roomKey
             console.log(`Custom message from ${message["displayName"]}: ${message["message"]}, ${message["roomKey"]}`);
             // Emit the message to all sockets in the room except the sender (note use io.to().emit() if you want to everyone in room)
             socket.to(message["roomKey"]).emit("receivedCustomMessage", message["message"]);


### PR DESCRIPTION
# Pull Request

## Description

Opening and closing clues are communicated to every player in room. necessary for game to be played. 
money values added as part of room data, so players can keep score 
greyed out boxes so players know which boxes were clicked

## What's in this change?

socket integration with the game board clicking. there is also a reactive element when a player receives a signal from the socket to open a clue as well. after that, the clue gets greyed out.
money values are added to the room variable in the socket side and can be retrieved. the structure is now changed to be objects of pairs of roomkeys and another object that has pairs of display name and money amount.

## Testing changes

tested by opening multiple clients and testing to make sure each part of the functionality works.
for example does setting money work. or when a player leaves a room, does that register.
or when i click does the other client also open the same box.
will write jest tests once structure of sockets is fully formed.

- Unit tests added/updated
- Manual testing steps or expected behavior changes
- Any issues encountered or edge cases to consider
