### PR TITLE
Update/game api

### DIFF
--- a/server/controllers/games.js
+++ b/server/controllers/games.js
@@ -53,6 +53,9 @@ router.get('/round-info/:gameId', (req, res) => {
         return res.status(404).json({ message: 'Game not found.' });
     }
 
+    // Update the last activity timestamp
+    game.lastActivity = Date.now();
+
     const currentRound = game.round;
     const questions = game.questions.filter(q => q.Round === currentRound);
     const categories = [...new Set(questions.map(q => q.Category))];
@@ -77,6 +80,9 @@ router.get('/question/:gameId', (req, res) => {
         return res.status(404).json({ message: 'Game not found.' });
     }
 
+    // Update the last activity timestamp
+    game.lastActivity = Date.now();
+
     const question = game.questions.find(q => q.Category === category && q.Value == value);
     if (!question) {
         return res.status(404).json({ message: 'Question not found for the specified category and value.' });
@@ -98,6 +104,9 @@ router.post('/next-round/:gameId', (req, res) => {
     if (!game) {
         return res.status(404).json({ message: 'Game not found.' });
     }
+
+    // Update the last activity timestamp
+    game.lastActivity = Date.now();
 
     if (game.round === 'Jeopardy!') {
         game.round = 'Double Jeopardy!';
@@ -147,6 +156,7 @@ router.post('/set-in-progress/:gameId', (req, res) => {
     }
 
     game.inProgress = true;
+    game.lastActivity = Date.now(); // Update last activity timestamp for tracking
 
     res.status(200).json({ message: `Game ${gameId} is now in progress.` });
 });

--- a/server/controllers/games.js
+++ b/server/controllers/games.js
@@ -38,11 +38,30 @@ router.post('/start-game', async (req, res) => {
 });
 
 
-// API endpoint to get all active game UIDs
+// API endpoint to get all active game UIDs with optional details
 router.get('/active-games', (req, res) => {
-    const activeGameIds = Object.keys(activeGames);
-    res.status(200).json({ activeGames: activeGameIds });
+    // Set default values for query parameters to 'false' to return only gameId by default
+    const { includePrivate = 'false', includeInProgress = 'false', includeMaxPlayers = 'false' } = req.query;
+
+    const activeGamesData = Object.entries(activeGames).map(([gameId, gameData]) => {
+        const gameInfo = { gameId };
+
+        if (includePrivate === 'true') {
+            gameInfo.isPrivate = gameData.isPrivate;
+        }
+        if (includeInProgress === 'true') {
+            gameInfo.inProgress = gameData.inProgress;
+        }
+        if (includeMaxPlayers === 'true') {
+            gameInfo.maxPlayers = gameData.maxPlayers;
+        }
+
+        return gameInfo;
+    });
+
+    res.status(200).json({ activeGames: activeGamesData });
 });
+
 
 // API endpoint to get round info for a game
 router.get('/round-info/:gameId', (req, res) => {

--- a/server/controllers/games.js
+++ b/server/controllers/games.js
@@ -6,6 +6,7 @@ const router = express.Router();
 
 // API endpoint to start a new game
 router.post('/start-game', async (req, res) => {
+    const { isPrivate = false, maxPlayers = 4 } = req.body;
     let validGame = false;
     let showNumber = null;
 
@@ -27,11 +28,15 @@ router.post('/start-game', async (req, res) => {
         questions: jeopardyData,
         lastActivity: Date.now(),
         warningSent: false,
-        round: 'Jeopardy!'
+        round: 'Jeopardy!',
+        isPrivate,     // Store the new properties
+        inProgress: false, // Always start with `inProgress` as false
+        maxPlayers     // Store the new properties
     };
 
     res.status(200).json({ message: 'Game started', gameId, totalQuestions: jeopardyData.length });
 });
+
 
 // API endpoint to get all active game UIDs
 router.get('/active-games', (req, res) => {
@@ -131,3 +136,17 @@ router.post('/end-game/:gameId', (req, res) => {
 });
 
 module.exports = router;
+
+// API endpoint to mark a game as in progress
+router.post('/set-in-progress/:gameId', (req, res) => {
+    const { gameId } = req.params;
+    const game = activeGames[gameId];
+
+    if (!game) {
+        return res.status(404).json({ message: 'Game not found.' });
+    }
+
+    game.inProgress = true;
+
+    res.status(200).json({ message: `Game ${gameId} is now in progress.` });
+});


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces routine checks for inactive games, ensures games are marked as "in progress" when appropriate, and adds optional arguments for game settings such as privacy, in-progress status, and maximum player count. Additionally, it updates the `active-games` endpoint to return only the requested game information, defaulting to just the `gameId` for minimal data return, while still supporting previous syntax. These changes improve game management and server efficiency by automatically ending idle games, enabling better control over game configurations, and customizing data responses.

- **Feature:** Automatic cleanup of inactive games, optional game configuration parameters, in-progress game management, and selective data return in `active-games`.
- **Motivation:** To optimize server resources by removing idle games, provide flexibility in game setup, and allow the current front-end to continue working by having requesting game details be optional.

## What's in this change?

- [x] Added a routine check using `setInterval` in `server.js` to assess the `lastActivity` timestamp of each game.
- [x] Games with over 30 minutes of inactivity are now automatically ended, using the `endGame` function from `gameUtils.js` for consistent cleanup.
- [x] Updated `/start-game` endpoint to accept optional parameters: `isPrivate`, `inProgress` (defaulting to `false`), and `maxPlayers`, allowing for greater flexibility in game creation.
- [x] Added a new endpoint, `/set-in-progress/:gameId`, to mark a game as "in progress" when necessary.
- [x] Enhanced the `active-games` endpoint to return only `gameId` by default, with options to include `isPrivate`, `inProgress`, and `maxPlayers` using query parameters.

## Testing changes

- **Manual Testing:** Verified the routine cleanup by starting several games and confirming that inactive games are removed after 30 minutes of inactivity. Tested optional parameters and the ability to set games to "in progress." Confirm this on the deployed render PR
