### PR TITLE
Non active users

### DIFF
--- a/client/app/[userid]/page.js
+++ b/client/app/[userid]/page.js
@@ -24,7 +24,7 @@ const JeopardyLoggedInPage = () => {
   const router = useRouter(); // Router instance to handle navigation
   const dispatch = useDispatch();
   const onlinePlayers = useSelector((state) => state.auth.activeUsers);
-  const { user } = useSelector((state) => state.auth);
+  const { user, loading } = useSelector((state) => state.auth);
   // const socketDisplayName = useSelector((state) => state.auth.user.displayName);
   const serverUrl = process.env.NEXT_PUBLIC_SERVER_URL;
 
@@ -67,7 +67,7 @@ const JeopardyLoggedInPage = () => {
   }, [dispatch, db]); 
 
   useEffect(() => {
-    if(!user) {
+    if(!user && !loading) {
       alert("You're not logged in. Please log in.");
       router.push("/");
     }

--- a/client/app/[userid]/page.js
+++ b/client/app/[userid]/page.js
@@ -24,6 +24,7 @@ const JeopardyLoggedInPage = () => {
   const router = useRouter(); // Router instance to handle navigation
   const dispatch = useDispatch();
   const onlinePlayers = useSelector((state) => state.auth.activeUsers);
+  const { user } = useSelector((state) => state.auth);
   // const socketDisplayName = useSelector((state) => state.auth.user.displayName);
   const serverUrl = process.env.NEXT_PUBLIC_SERVER_URL;
 
@@ -66,6 +67,11 @@ const JeopardyLoggedInPage = () => {
   }, [dispatch, db]); 
 
   useEffect(() => {
+    if(!user) {
+      alert("You're not logged in. Please log in.");
+      router.push("/");
+    }
+
     fetchAvailableRooms();
   }, []); 
 

--- a/client/app/components/AppLayout.js
+++ b/client/app/components/AppLayout.js
@@ -1,0 +1,56 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from 'react-redux';
+import { useRouter } from "next/navigation";
+import { logoutUser } from "../redux/authSlice";
+
+const inactivityTimeout = 1000 * 60 * 60; // 1 hour
+let inactivityTimer;
+
+function AppLayout({ children }) {
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const { user } = useSelector((state) => state.auth);
+
+  const resetInactivityTimer = () => {
+    localStorage.setItem('lastActivity', Date.now().toString());
+    clearTimeout(inactivityTimer);
+    inactivityTimer = setTimeout(logoutOnInactivity, inactivityTimeout);
+  };
+
+  const logoutOnInactivity = () => {
+    console.log("Logging out due to inactivity...");
+    if (user) {
+      console.log(`updating ${user.displayName}, ${user.uid} status to offline from logoutOnInactivity`);
+      dispatch(logoutUser());
+      alert("You have been logged out due to inactivity.");
+      router.push("/");
+    }
+  };
+
+  const checkInactivityOnLoad = () => {
+    const lastActivity = localStorage.getItem('lastActivity');
+    if (lastActivity) {
+      const timeElapsed = Date.now() - parseInt(lastActivity);
+      if (timeElapsed > inactivityTimeout && user) {
+        logoutOnInactivity();
+      }
+    }
+  };
+
+  useEffect(() => {
+    checkInactivityOnLoad();
+    window.addEventListener("mousemove", resetInactivityTimer);
+    window.addEventListener("keydown", resetInactivityTimer);
+    return () => {
+      window.removeEventListener("mousemove", resetInactivityTimer);
+      window.removeEventListener("keydown", resetInactivityTimer);
+      clearTimeout(inactivityTimer);
+    };
+  }, [user]);
+
+  return <>{children}</>;
+}
+
+export default AppLayout;

--- a/client/app/components/accountEmailPassword.js
+++ b/client/app/components/accountEmailPassword.js
@@ -12,23 +12,7 @@ export default function AccountEmailPassword({action}) {
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const dispatch = useDispatch();
-
     const router = useRouter();
-    useEffect(() => {
-        const checkAuthState = async() => {
-            const auth = await getFirebaseAuth();
-            const unsubscribe = auth.onAuthStateChanged((user) => {
-                if (user) {
-                  router.push(`/${user.uid}`); 
-                }
-            });
-        
-            // Cleanup the listener when the component is unmounted
-            return () => unsubscribe();
-        };
-
-        checkAuthState();
-    }, [router]);      
 
     const checkPasswordRequirements = (password) => {
         const passwordRegex = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}$/;
@@ -65,6 +49,7 @@ export default function AccountEmailPassword({action}) {
                 if (response.ok) {
                     await dispatch(createUserDocument(user.uid, user.email));
                     alert("Account created!");
+                    localStorage.setItem('lastActivity', Date.now().toString());
                     router.push(`/${uid}`);
                 }else if(response.status === 400) {
                     console.error('Error:', data.message);
@@ -108,6 +93,7 @@ export default function AccountEmailPassword({action}) {
             if (response.ok) {
                 await dispatch(updateLoginTime(uid));
                 alert("Signed in!");
+                localStorage.setItem('lastActivity', Date.now().toString());
                 router.push(`/${uid}`);
             }else if(response.status === 400) {
                 console.error('Error:', data.message);

--- a/client/app/components/accountEmailPassword.js
+++ b/client/app/components/accountEmailPassword.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import { getFirebaseAuth } from '../lib/firebaseClient';
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from 'firebase/auth';
 import { createUserDocument, updateLoginTime } from '../redux/authSlice';
@@ -14,6 +14,22 @@ export default function AccountEmailPassword({action}) {
     const dispatch = useDispatch();
 
     const router = useRouter();
+    useEffect(() => {
+        const checkAuthState = async() => {
+            const auth = await getFirebaseAuth();
+            const unsubscribe = auth.onAuthStateChanged((user) => {
+                if (user) {
+                  router.push(`/${user.uid}`); 
+                }
+            });
+        
+            // Cleanup the listener when the component is unmounted
+            return () => unsubscribe();
+        };
+
+        checkAuthState();
+    }, [router]);      
+
     const checkPasswordRequirements = (password) => {
         const passwordRegex = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}$/;
         return passwordRegex.test(password);

--- a/client/app/components/navbar.js
+++ b/client/app/components/navbar.js
@@ -35,6 +35,7 @@ const Navbar = () => {
         try{
             await dispatch(logoutUser());
             alert("Successfully logged out!");
+            localStorage.removeItem('lastActivity');
             router.push("/");
         }catch(error){
             console.error('Error:', error);

--- a/client/app/layout.js
+++ b/client/app/layout.js
@@ -6,6 +6,7 @@ import ReduxProvider from "./ReduxProvider";
 import { Provider, useDispatch } from "react-redux";
 import { store } from "./redux/store";
 import { monitorAuthState } from "./redux/authSlice";
+import AppLayout from "./components/AppLayout";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -35,9 +36,9 @@ export default function RootLayout({ children }) {
       <DispatchEffect />
       <html lang="en">
         <body className={`${geistSans.variable} ${geistMono.variable}`}>
-            <ReduxProvider>
+            <AppLayout>
               {children}
-            </ReduxProvider>
+            </AppLayout>
         </body>
       </html>
     </Provider>

--- a/client/app/lib/firebaseClient.js
+++ b/client/app/lib/firebaseClient.js
@@ -1,6 +1,6 @@
 import { initializeApp, getApp, getApps } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
-import { getAuth, setPersistence, browserLocalPersistence } from "firebase/auth";
+import { getAuth, setPersistence, browserLocalPersistence, signOut } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -40,3 +40,13 @@ export const getFirebaseFirestore = () => {
   }
   return firestore;
 }
+
+export const signOutFirebase = async() => {
+  try {
+    const auth = await getFirebaseAuth();
+    await signOut(auth);
+    console.log("User signed out");
+  } catch (error) {
+    console.error("Error signing out:", error);
+  }
+};

--- a/client/app/page.js
+++ b/client/app/page.js
@@ -5,13 +5,9 @@ import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import jeopardyLogo from "./icons/Jeopardy-Symbol.png";
 import AccountEmailPassword from "./components/accountEmailPassword";
-import { updateUserStatus, logoutUser } from "./redux/authSlice";
 import { useDispatch, useSelector } from 'react-redux';
 import { useRouter } from "next/navigation";
 import { useSocket } from "./socketClient";
-
-const inactivityTimeout = 1000 * 60 * 1; // 1 hour
-let inactivityTimer;
 
 export default function Home() {
   const router = useRouter();
@@ -19,44 +15,8 @@ export default function Home() {
   const [Jeopardies, setJeopardies] = useState([]);
   const [displayForm, setDisplayForm] = useState("login");
   const { user, loading } = useSelector((state) => state.auth);
-  console.log("User:", user);
   const dispatch = useDispatch();
-
   const socket = useSocket();
-
-  const resetInactivityTimer = () => {
-    localStorage.setItem('lastActivity', Date.now().toString());
-    clearTimeout(inactivityTimer);
-    inactivityTimer = setTimeout(logoutOnInactivity, inactivityTimeout);
-  };
-
-  const logoutOnInactivity = () => {
-    if (user) {
-      console.log("Logging out ", user);
-      dispatch(updateUserStatus(user.uid, user.displayName, 'offline'));
-      dispatch(logoutUser());
-      alert("You have been logged out due to inactivity.");
-      router.push("/");
-    }
-  }
-
-  // returns true if user is logged out due to inactivity; false otherwise
-  const checkInactivityOnLoad = () => {
-    console.log("Checking inactivity on load");
-    const lastActivity = localStorage.getItem('lastActivity');
-
-    if (lastActivity) {
-      const timeElapsed = Date.now() - parseInt(lastActivity);
-
-      if (timeElapsed > inactivityTimeout && user) {
-        console.log("Logging out due to inactivity");
-        logoutOnInactivity();
-        return true;
-      }
-    }
-
-    return false;
-  };
 
   useEffect(() => {
     fetch(process.env.NEXT_PUBLIC_SERVER_URL + "/api/jeopardy")
@@ -68,25 +28,15 @@ export default function Home() {
       .catch((error) => {
         console.error("Error fetching data:", error);
       });
-
-    window.addEventListener('mousemove', resetInactivityTimer);
-    window.addEventListener('keydown', resetInactivityTimer);
-
-    return () => {
-      window.removeEventListener('mousemove', resetInactivityTimer);
-      window.removeEventListener('keydown', resetInactivityTimer);
-      clearTimeout(inactivityTimer);
-    };
   }, []); 
 
     // Effect to check user authentication and redirect if necessary
     useEffect(() => {
       if (user && !loading) {
-        const isInactive = checkInactivityOnLoad();
-        if (!isInactive) {
-          router.push(`/${user.uid}`);
-        }
-      } else {
+        router.push(`/${user.uid}`);
+      } else if(loading) {
+        console.log("Loading user data...");
+      }else {
         console.log("User is not logged in")
       }
     }, [user, router, loading]);
@@ -118,6 +68,8 @@ export default function Home() {
       </div>
 
       <AccountEmailPassword action={displayForm}/>
+
+      {loading ? <p className={styles.loading}>Loading...</p> : null}
 
       {displayForm === "login" ? 
       <p className={styles.notAUser}>

--- a/client/app/page.js
+++ b/client/app/page.js
@@ -10,7 +10,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useRouter } from "next/navigation";
 import { useSocket } from "./socketClient";
 
-const inactivityTimeout = 1000 * 60 * 60; // 1 hour
+const inactivityTimeout = 1000 * 60 * 1; // 1 hour
 let inactivityTimer;
 
 export default function Home() {
@@ -18,7 +18,7 @@ export default function Home() {
   const [message, setMessage] = useState("Loading");
   const [Jeopardies, setJeopardies] = useState([]);
   const [displayForm, setDisplayForm] = useState("login");
-  const { user } = useSelector((state) => state.auth);
+  const { user, loading } = useSelector((state) => state.auth);
   console.log("User:", user);
   const dispatch = useDispatch();
 
@@ -52,16 +52,10 @@ export default function Home() {
         console.log("Logging out due to inactivity");
         logoutOnInactivity();
         return true;
-      } else {
-        resetInactivityTimer();
-        return false;
       }
-
-    } else {
-      console.log("No last activity found");
-      resetInactivityTimer();
-      return false;
     }
+
+    return false;
   };
 
   useEffect(() => {
@@ -87,13 +81,15 @@ export default function Home() {
 
     // Effect to check user authentication and redirect if necessary
     useEffect(() => {
-      if (user) {
+      if (user && !loading) {
         const isInactive = checkInactivityOnLoad();
         if (!isInactive) {
           router.push(`/${user.uid}`);
         }
+      } else {
+        console.log("User is not logged in")
       }
-    }, [user, router]);
+    }, [user, router, loading]);
 
   useEffect(() => {
     if (Jeopardies) {

--- a/client/app/page.js
+++ b/client/app/page.js
@@ -5,14 +5,64 @@ import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import jeopardyLogo from "./icons/Jeopardy-Symbol.png";
 import AccountEmailPassword from "./components/accountEmailPassword";
+import { updateUserStatus, logoutUser } from "./redux/authSlice";
+import { useDispatch, useSelector } from 'react-redux';
+import { useRouter } from "next/navigation";
 import { useSocket } from "./socketClient";
 
+const inactivityTimeout = 1000 * 60 * 60; // 1 hour
+let inactivityTimer;
+
 export default function Home() {
+  const router = useRouter();
   const [message, setMessage] = useState("Loading");
   const [Jeopardies, setJeopardies] = useState([]);
   const [displayForm, setDisplayForm] = useState("login");
+  const { user } = useSelector((state) => state.auth);
+  console.log("User:", user);
+  const dispatch = useDispatch();
 
   const socket = useSocket();
+
+  const resetInactivityTimer = () => {
+    localStorage.setItem('lastActivity', Date.now().toString());
+    clearTimeout(inactivityTimer);
+    inactivityTimer = setTimeout(logoutOnInactivity, inactivityTimeout);
+  };
+
+  const logoutOnInactivity = () => {
+    if (user) {
+      console.log("Logging out ", user);
+      dispatch(updateUserStatus(user.uid, user.displayName, 'offline'));
+      dispatch(logoutUser());
+      alert("You have been logged out due to inactivity.");
+      router.push("/");
+    }
+  }
+
+  // returns true if user is logged out due to inactivity; false otherwise
+  const checkInactivityOnLoad = () => {
+    console.log("Checking inactivity on load");
+    const lastActivity = localStorage.getItem('lastActivity');
+
+    if (lastActivity) {
+      const timeElapsed = Date.now() - parseInt(lastActivity);
+
+      if (timeElapsed > inactivityTimeout && user) {
+        console.log("Logging out due to inactivity");
+        logoutOnInactivity();
+        return true;
+      } else {
+        resetInactivityTimer();
+        return false;
+      }
+
+    } else {
+      console.log("No last activity found");
+      resetInactivityTimer();
+      return false;
+    }
+  };
 
   useEffect(() => {
     fetch(process.env.NEXT_PUBLIC_SERVER_URL + "/api/jeopardy")
@@ -24,7 +74,26 @@ export default function Home() {
       .catch((error) => {
         console.error("Error fetching data:", error);
       });
-  }, []);
+
+    window.addEventListener('mousemove', resetInactivityTimer);
+    window.addEventListener('keydown', resetInactivityTimer);
+
+    return () => {
+      window.removeEventListener('mousemove', resetInactivityTimer);
+      window.removeEventListener('keydown', resetInactivityTimer);
+      clearTimeout(inactivityTimer);
+    };
+  }, []); 
+
+    // Effect to check user authentication and redirect if necessary
+    useEffect(() => {
+      if (user) {
+        const isInactive = checkInactivityOnLoad();
+        if (!isInactive) {
+          router.push(`/${user.uid}`);
+        }
+      }
+    }, [user, router]);
 
   useEffect(() => {
     if (Jeopardies) {

--- a/client/app/page.module.css
+++ b/client/app/page.module.css
@@ -51,6 +51,10 @@
   /* margin-bottom: 10px; */
 }
 
+.loading {
+  padding-top: 20px;
+}
+
 .submitFormButton {
   width: fit-content;
   padding: 10px 20px;

--- a/client/app/redux/authSlice.js
+++ b/client/app/redux/authSlice.js
@@ -226,6 +226,7 @@
           }
         }
       } else {
+        localStorage.removeItem('lastActivity');
         dispatch(clearUser());
       }
 

--- a/client/app/redux/authSlice.js
+++ b/client/app/redux/authSlice.js
@@ -176,25 +176,28 @@
   export const updateUserStatus = (uid, displayName, status) => async (dispatch, getState) => {
     console.log("From updateUserStatus thunk:");
     console.log("uid:", uid, "displayName:", displayName, "status:", status);
-    try{
-        dispatch(setLoading(true));
-        const userRef = doc(getFirebaseFirestore(), "users", uid);
-        await updateDoc(userRef, {status});
 
-        const {activeUsers} = getState().auth;
-        console.log("activeUsers from updateUserStatus:", activeUsers, "uid:", uid);
-        console.log("current status", status);
-          
-        if(status === 'offline' && activeUsers.includes(displayName)) {
-          console.log("removing active user displayName", displayName);
-          await dispatch(removeActiveUser(displayName));
-        }
-        else if(status === 'online' && !activeUsers.includes(displayName)) {
-          console.log("adding active user displayName", displayName);
-          await dispatch(addActiveUser(displayName));
-        }
-    } catch (error) {
-        console.error('Error getting data:', error);
+    if(displayName) {
+      try{
+          dispatch(setLoading(true));
+          const userRef = doc(getFirebaseFirestore(), "users", uid);
+          await updateDoc(userRef, {status});
+
+          const {activeUsers} = getState().auth;
+          console.log("activeUsers from updateUserStatus:", activeUsers, "uid:", uid);
+          console.log("current status", status);
+            
+          if(status === 'offline' && activeUsers.includes(displayName)) {
+            console.log("removing active user displayName", displayName);
+            await dispatch(removeActiveUser(displayName));
+          }
+          else if(status === 'online' && !activeUsers.includes(displayName)) {
+            console.log("adding active user displayName", displayName);
+            await dispatch(addActiveUser(displayName));
+          }
+      } catch (error) {
+          console.error('Error getting data:', error);
+      }
     }
   }
 

--- a/client/app/redux/authSlice.js
+++ b/client/app/redux/authSlice.js
@@ -76,16 +76,17 @@
   // fetches from fireStore 
   export const fetchUserData = (userId) => async (dispatch) => {
     if (!userId) return console.error('No user ID provided!');
+    console.log("FETCHING USER DATA")
 
-    dispatch(setLoading(true));
+    await dispatch(setLoading(true));
     const db = getFirebaseFirestore();
     const userRef = doc(db, 'users', userId);
     const userSnapshot = await getDoc(userRef);
 
     if (userSnapshot.exists()) {
-      console.log('User data:', userSnapshot.data());
+      console.log('User data from fetchUserData:', userSnapshot.data());
       const userData = userSnapshot.data();
-      dispatch(setUser({
+      await dispatch(setUser({
         uid: userData.uid,
         email: userData.email,
         displayName: userData.displayName,
@@ -177,55 +178,59 @@
     console.log("From updateUserStatus thunk:");
     console.log("uid:", uid, "displayName:", displayName, "status:", status);
 
-    if(displayName) {
-      try{
-          dispatch(setLoading(true));
-          const userRef = doc(getFirebaseFirestore(), "users", uid);
-          await updateDoc(userRef, {status});
+    try{
+      dispatch(setLoading(true));
+      
+      if(displayName) {
+        const userRef = doc(getFirebaseFirestore(), "users", uid);
+        await updateDoc(userRef, {status});
 
-          const {activeUsers} = getState().auth;
-          console.log("activeUsers from updateUserStatus:", activeUsers, "uid:", uid);
-          console.log("current status", status);
-            
-          if(status === 'offline' && activeUsers.includes(displayName)) {
-            console.log("removing active user displayName", displayName);
-            await dispatch(removeActiveUser(displayName));
-          }
-          else if(status === 'online' && !activeUsers.includes(displayName)) {
-            console.log("adding active user displayName", displayName);
-            await dispatch(addActiveUser(displayName));
-          }
-      } catch (error) {
-          console.error('Error getting data:', error);
+        const {activeUsers} = getState().auth;
+        console.log("activeUsers from updateUserStatus:", activeUsers, "uid:", uid);
+        console.log("current status", status);
+          
+        if(status === 'offline' && activeUsers.includes(displayName)) {
+          console.log("removing active user displayName", displayName);
+          await dispatch(removeActiveUser(displayName));
+        }
+        else if(status === 'online' && !activeUsers.includes(displayName)) {
+          console.log("adding active user displayName", displayName);
+          await dispatch(addActiveUser(displayName));
+        }
       }
+    } catch (error) {
+        console.error('Error getting data:', error);
     }
   }
 
   let unsubscribeAuth = null;
 
-  export const monitorAuthState = () => (dispatch, getState) => {
+  export const monitorAuthState = () => async(dispatch, getState) => {
     if(unsubscribeAuth) {
       unsubscribeAuth(); // calls existing function
       unsubscribeAuth = null; // resetting to prevent it from being called again
     }
 
     initializeFirebase();
-    const auth = getAuth();
+    const auth = await getAuth();
 
     dispatch(setLoading(true));
 
     unsubscribeAuth = onAuthStateChanged(auth, async(user) => {
       if(user) {
-        console.log("current user: ", user);
+        console.log("current user from onAuthStateChanged: ", user);
         const { uid, email, displayName } = user;
-        await dispatch(setUser({ uid, email, displayName }));
+        console.log("From onAuthStateChanged:");
+        console.log("uid:", uid, "email:", email, "displayName:", displayName);
         
         const userData = await dispatch(fetchUserData(uid));
+
         if (userData) {
-          console.log("userData:", userData);
+          console.log("user data returned:", userData);
+
           if (userData.status === 'offline') {
             console.log("updating user status to online from unsubscribeAuth");
-            await dispatch(updateUserStatus(uid, displayName, 'online'));
+            await dispatch(updateUserStatus(userData.uid, userData.displayName, 'online'));
           }
         }
       } else {


### PR DESCRIPTION
# Pull Request

## Description
To fix the overflow of accounts under active users, Users who are idle for over an hour are logged off. In addition, to accommodate cases where users do not directly log off from previous sessions, their log in information are saved and used to log them back in.

## What's in this change?

Outline the specific changes that are being introduced. Use bullet points to break them down where appropriate.

- [X] Added global inactivity tracker to reduce traffic of idle users
- [X] Fixed "/" route to redirect users to their home page if they have not previously logged out
- [X] Revised functionalities in authSlice that were inefficient for monitoring activeUser and user state

## Testing changes
N/A
