### PR TITLE
updates lastLogin field instead of creating new date field

### DIFF
--- a/client/app/redux/authSlice.js
+++ b/client/app/redux/authSlice.js
@@ -102,8 +102,8 @@
     try {
       const db = getFirebaseFirestore();
       const userRef = doc(db, "users", uid);
-      const date = new Date();
-      await updateDoc(userRef, {date});
+      const lastLogin = new Date();
+      await updateDoc(userRef, {lastLogin});
     } catch (error) {
       console.error('Error updating login time:', error);
     }


### PR DESCRIPTION
# Pull Request

## Description
Quick fix of updating user login time field in firestore rather than creating a new field "date" 

## What's in this change?

- [ ] Changed variable name for updating firestore to correspond with field name

## Testing changes
