### PR TITLE
Player Ready Status Toggling with Ready Button

### DIFF
--- a/client/app/game-board/page.js
+++ b/client/app/game-board/page.js
@@ -729,7 +729,7 @@ export default function GameBoardPage() {
         <h2>Player Scores</h2>
         {Object.entries(playerScores).map(([player, score]) => (
           <div key={player} className={styles.playerScore}>
-            {player}: {score}
+            {player}: {score.money}
           </div>
         ))}
         <div className={styles.playerSelectingNext}>

--- a/client/app/socketClient.js
+++ b/client/app/socketClient.js
@@ -1,306 +1,306 @@
-  import { useEffect, useState, useRef } from "react";
-  import { io } from "socket.io-client";
-  import { useSelector } from "react-redux";
+import { useEffect, useState, useRef } from "react";
+import { io } from "socket.io-client";
+import { useSelector } from "react-redux";
 
-  export const useSocket = (onMessageReceivedCallback) => {
-    const socketRef = useRef(null);
-    const [roomKey, setRoomKey] = useState("");
-    const [socketDisplayName, setSocketDisplayName] = useState("");
-    const user = useSelector((state) => state.auth.user);
-    const [socketMessage, setSocketMessage] = useState("");
-    const [roomsData, setRoomsData] = useState(null);
-    const [playersInRoom, setPlayersInRoom] = useState([]);
-    const [money, setMoney] = useState(0);
-    // Create a ref to store socketDisplayName synchronously, as diplayName then setting roomKey timing matters
-    const socketDisplayNameRef = useRef("");
+export const useSocket = (onMessageReceivedCallback) => {
+  const socketRef = useRef(null);
+  const [roomKey, setRoomKey] = useState("");
+  const [socketDisplayName, setSocketDisplayName] = useState("");
+  const user = useSelector((state) => state.auth.user);
+  const [socketMessage, setSocketMessage] = useState("");
+  const [roomsData, setRoomsData] = useState(null);
+  const [playersInRoom, setPlayersInRoom] = useState([]);
+  const [money, setMoney] = useState(0);
+  // Create a ref to store socketDisplayName synchronously, as diplayName then setting roomKey timing matters
+  const socketDisplayNameRef = useRef("");
 
-    // setting socket displayName from logged in user
-    useEffect(() => {
-      if (user && (window.location.pathname != "/")) {
-        setDisplayName(user.displayName);
-        socketDisplayNameRef.current = user.displayName;
-      } 
-      else if (window.location.pathname != "/") {
-        const storedDisplayName = localStorage.getItem("displayName");
-        if (storedDisplayName) {
-          setSocketDisplayName(storedDisplayName);
-          socketDisplayNameRef.current = storedDisplayName;
-          console.log(`[Client-side Acknowledgement] Retrieved display name from localStorage: ${storedDisplayName}`);
-        }
+  // setting socket displayName from logged in user
+  useEffect(() => {
+    if (user && (window.location.pathname != "/")) {
+      setDisplayName(user.displayName);
+      socketDisplayNameRef.current = user.displayName;
+    } 
+    else if (window.location.pathname != "/") {
+      const storedDisplayName = localStorage.getItem("displayName");
+      if (storedDisplayName) {
+        setSocketDisplayName(storedDisplayName);
+        socketDisplayNameRef.current = storedDisplayName;
+        console.log(`[Client-side Acknowledgement] Retrieved display name from localStorage: ${storedDisplayName}`);
       }
-    }, [user]);
+    }
+  }, [user]);
 
-    // Change localStorage based on the current route, this is how we handle persistence
-    useEffect(() => {
-      if (typeof window !== "undefined") {
-        const currentPath = window.location.pathname;
+  // Change localStorage based on the current route, this is how we handle persistence
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const currentPath = window.location.pathname;
 
-        if (currentPath === "/") {
-          // On route '/' meaning user starts fresh, clear localStorage, otherwise we assume user wants to persist connection
-          localStorage.removeItem("displayName");
-          localStorage.removeItem("roomKey");
-          localStorage.removeItem("money"); // Clear money on fresh start
-          setSocketDisplayName("");
-          setRoomKey("");
-          setMoney(0);
-          socketDisplayNameRef.current = "";
-          console.log("[Client-side Acknowledgement] localStorage cleared.");
-        } else {
-          (async () => {
-            // First, retrieve and set displayName
-            const storedDisplayName = localStorage.getItem("displayName");
-            if (storedDisplayName) {
-              await new Promise((resolve) => {
-                setSocketDisplayName(storedDisplayName);
-                socketDisplayNameRef.current = storedDisplayName;
-                console.log(`[Client-side Acknowledgement] Retrieved display name from localStorage: ${storedDisplayName}`);
-                resolve();
-              });
-            }
-    
-            // After displayName is set, retrieve and set roomKey
-            const storedRoomKey = localStorage.getItem("roomKey");
-            if (storedRoomKey) {
-              setRoomKey(storedRoomKey);
-              console.log(`[Client-side Acknowledgement] Retrieved room key from localStorage: ${storedRoomKey}`);
-            }
+      if (currentPath === "/") {
+        // On route '/' meaning user starts fresh, clear localStorage, otherwise we assume user wants to persist connection
+        localStorage.removeItem("displayName");
+        localStorage.removeItem("roomKey");
+        localStorage.removeItem("money"); // Clear money on fresh start
+        setSocketDisplayName("");
+        setRoomKey("");
+        setMoney(0);
+        socketDisplayNameRef.current = "";
+        console.log("[Client-side Acknowledgement] localStorage cleared.");
+      } else {
+        (async () => {
+          // First, retrieve and set displayName
+          const storedDisplayName = localStorage.getItem("displayName");
+          if (storedDisplayName) {
+            await new Promise((resolve) => {
+              setSocketDisplayName(storedDisplayName);
+              socketDisplayNameRef.current = storedDisplayName;
+              console.log(`[Client-side Acknowledgement] Retrieved display name from localStorage: ${storedDisplayName}`);
+              resolve();
+            });
+          }
+  
+          // After displayName is set, retrieve and set roomKey
+          const storedRoomKey = localStorage.getItem("roomKey");
+          if (storedRoomKey) {
+            setRoomKey(storedRoomKey);
+            console.log(`[Client-side Acknowledgement] Retrieved room key from localStorage: ${storedRoomKey}`);
+          }
 
-            // After roomKey is set, retrieve and set playersInRoom
-            if (storedRoomKey && socketRef.current) {
-              console.log("[Client-side Acknowledgement] Requesting players in the current room...");
-              socketRef.current.emit("getPlayersInRoom", { roomKey: storedRoomKey });
-              console.log(`[Client-side Acknowledgement] Requesting players in room ${storedRoomKey}...`);
-            }
-    
-            // Retrieve and set money independently
-            const storedMoney = localStorage.getItem("money");
-            if (storedMoney) {
-              setMoney(Number(storedMoney));
-              console.log(`[Client-side Acknowledgement] Retrieved money from localStorage: ${storedMoney}`);
-            }
-          })();
-        }
+          // After roomKey is set, retrieve and set playersInRoom
+          if (storedRoomKey && socketRef.current) {
+            console.log("[Client-side Acknowledgement] Requesting players in the current room...");
+            socketRef.current.emit("getPlayersInRoom", { roomKey: storedRoomKey });
+            console.log(`[Client-side Acknowledgement] Requesting players in room ${storedRoomKey}...`);
+          }
+  
+          // Retrieve and set money independently
+          const storedMoney = localStorage.getItem("money");
+          if (storedMoney) {
+            setMoney(Number(storedMoney));
+            console.log(`[Client-side Acknowledgement] Retrieved money from localStorage: ${storedMoney}`);
+          }
+        })();
       }
-    }, []);
+    }
+  }, []);
 
-    useEffect(() => {
-      const socketInstance = io(process.env.NEXT_PUBLIC_SERVER_URL); 
+  useEffect(() => {
+    const socketInstance = io(process.env.NEXT_PUBLIC_SERVER_URL); 
 
-      socketRef.current = socketInstance;
+    socketRef.current = socketInstance;
 
-      console.log(
-        "[Client-side Acknowledgement] Socket initialized. Attaching listeners and emitting events..."
-      );
+    console.log(
+      "[Client-side Acknowledgement] Socket initialized. Attaching listeners and emitting events..."
+    );
 
-      socketInstance.on("confirmReceivedRoom", (message) => {
-        console.log("[From Server] - ", message);
-      });
+    socketInstance.on("confirmReceivedRoom", (message) => {
+      console.log("[From Server] - ", message);
+    });
 
-      socketInstance.on("promptDisplayName", (message) => {
-        console.log("[From Server: Display Name Error] - ", message);
-      });
+    socketInstance.on("promptDisplayName", (message) => {
+      console.log("[From Server: Display Name Error] - ", message);
+    });
 
-      socketInstance.on("newPlayerJoined", (message) => {
-        console.log("[From Server: New player joined] -", message);
-      });
+    socketInstance.on("newPlayerJoined", (message) => {
+      console.log("[From Server: New player joined] -", message);
+    });
 
-      socketInstance.on("player_joined", (message) => {
-        console.log("[From Server: Player joined] -", message);
-      });
+    socketInstance.on("player_joined", (message) => {
+      console.log("[From Server: Player joined] -", message);
+    });
 
-      socketInstance.on("playersInRoom", (players) => {
-        const playerList = Object.entries(players).map(([name, attributes]) => ({
-          name,
-          ...attributes,
+    socketInstance.on("playersInRoom", (players) => {
+      const playerList = Object.entries(players).map(([name, attributes]) => ({
+        name,
+        ...attributes,
       }));
-        setPlayersInRoom(playerList);
-        console.log("[From Server: Players in room] -", playerList);
-      });
+      
+      setPlayersInRoom(playerList);
+      console.log("[From Server: Players in room] -", playerList);
+    });
 
-      socketInstance.on("receivedCustomMessage", (message) => {
+    socketInstance.on("receivedCustomMessage", (message) => {
+      console.log(
+        "[From Server: Custom message received] -",
+        message["action"],
+        message["content"]
+      );
+      if (onMessageReceivedCallback) {
+        onMessageReceivedCallback(message); // Trigger the callback when a message is received
+      }
+    });
+
+    // Receive rooms object from server and we opt to store it
+    socketInstance.on("receiveRooms", (rooms) => {
+      // console.log("[From Server] - Rooms data received from server:", rooms);
+      setRoomsData(rooms);
+      // console.log("[From Server: Rooms data received from server] -", rooms);
+    });
+
+    return () => {
+      if (socketRef.current) {
+        socketRef.current.disconnect();
+      }
+    };
+  }, []);
+
+  // Start of our emit functions
+  useEffect(() => {
+    if (socketRef.current && socketDisplayName) {
+      socketRef.current.emit("displayName", socketDisplayName);
+      localStorage.setItem("displayName", socketDisplayName);
+      console.log(`[Client-side Acknowledgement] Display name set automatically to ${socketDisplayName}` );
+    }
+  }, [socketDisplayName]);
+
+  useEffect(() => {
+    if (socketRef.current && roomKey) {
+      socketRef.current.emit("roomKey", roomKey);
+      localStorage.setItem("roomKey", roomKey);
+      console.log(`[Client-side Acknowledgement] Room key set automatically to ${roomKey}`);
+      socketRef.current.emit("getPlayersInRoom", { roomKey });
+    }
+  }, [roomKey]);
+
+  // Listen for updated player list from the server
+  useEffect(() => {
+    if (socketRef.current) {
+      console.log("[Client-side Acknowledgement] Listening for updated player list...");
+      socketRef.current.on("playersInRoom", (players) => {
+        setPlayersInRoom(players);  // Update the players in room state
+        console.log("[From Server: Players in room] -", players);
+      });
+    }
+  }, []);
+
+  // Load money amount from localStorage on component mount
+  useEffect(() => {
+    const storedMoney = localStorage.getItem("money");
+    if (storedMoney) {
+      setMoney(Number(storedMoney));
+      console.log("[Client-side Acknowledgement] Loaded money from localStorage.");
+    }
+  }, []);
+
+  // Save money amount to localStorage whenever it updates
+  useEffect(() => {
+    if (money !== null) {
+      localStorage.setItem("money", money);
+    }
+  }, [money]);
+
+  useEffect(() => {
+    if (socketRef.current && socketMessage) {
+      socketRef.current.emit("customMessage", {
+        roomKey: roomKey,
+        displayName: socketDisplayName,
+        message: socketMessage,
+      });
+    }
+  }, [socketMessage]);
+
+  // Ensure the getRooms function is initialized once the socket is ready
+  useEffect(() => {
+    if (socketRef.current) {
+      window.getRooms = () => {
+        socketRef.current.emit("getRooms"); // here we make the actual request for the rooms object from server
+      };
+    } else {
+      window.getRooms = () => {
+        console.log("[Client-side Acknowledgement] Socket is not initialized.");
+      };
+    }
+  }, []);
+
+  useEffect(() => {
+    if (socketRef.current) {
+      window.getPlayersInRoom = () => {
         console.log(
-          "[From Server: Custom message received] -",
-          message["action"],
-          message["content"]
+          "[Client-side Acknowledgement] Requesting players in the current room..."
         );
-        if (onMessageReceivedCallback) {
-          onMessageReceivedCallback(message); // Trigger the callback when a message is received
+        socketRef.current.emit("getPlayersInRoom");
+      };
+
+      socketRef.current.on("playersInRoom", (players) => {
+        console.log("[From Server: Players in room] -", players);
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.setDisplayName = (name) => {
+        if(name === "" || name === null || name === "null") {
+          console.log("[Client-side Acknowledgement] Display name cannot be empty.");
+          return;
         }
-      });
 
-      // Receive rooms object from server and we opt to store it
-      socketInstance.on("receiveRooms", (rooms) => {
-        // console.log("[From Server] - Rooms data received from server:", rooms);
-        setRoomsData(rooms);
-        // console.log("[From Server: Rooms data received from server] -", rooms);
-      });
+        setSocketDisplayName(name);
+        socketDisplayNameRef.current = name; // Update ref
+        localStorage.setItem("displayName", name);
+        console.log(
+          `[Client-side Acknowledgement] Display name set to: "${name}"`
+        );
+      };
 
-      return () => {
+      window.addPlayerToRoom = (roomKey, displayName) => {
         if (socketRef.current) {
-          socketRef.current.disconnect();
+          console.log(`[Client-side Acknowledgement] Adding player "${displayName}" to room "${roomKey}"...`);
+          socketRef.current.emit("setPlayersInRoom", {
+            roomKey: roomKey,
+            displayName: displayName,
+          });
+        }
+
+        setPlayersInRoom((prevPlayers) => {
+          return [...prevPlayers, {name: displayName}];
+        });
+
+        localStorage.setItem("players", JSON.stringify(playersInRoom));
+
+        console.log(`[Client-side Acknowledgement] Player "${displayName}" added to room "${roomKey}"`);
+      }
+
+      window.setRoomKey = (key) => {
+        if (socketDisplayNameRef.current) {
+          setRoomKey(key);
+          localStorage.setItem("roomKey", key);
+          console.log(`[Client-side Acknowledgement] Room key set to: ${key}`);
+        } else {
+          console.log(
+            "[Client-side Acknowledgement] Cannot set room key before setting display name."
+          );
         }
       };
-    }, []);
 
-    // Start of our emit functions
-    useEffect(() => {
-      if (socketRef.current && socketDisplayName) {
-        socketRef.current.emit("displayName", socketDisplayName);
-        localStorage.setItem("displayName", socketDisplayName);
-        console.log(`[Client-side Acknowledgement] Display name set automatically to ${socketDisplayName}` );
-      }
-    }, [socketDisplayName]);
-
-    useEffect(() => {
-      if (socketRef.current && roomKey) {
-        socketRef.current.emit("roomKey", roomKey);
-        localStorage.setItem("roomKey", roomKey);
-        console.log(`[Client-side Acknowledgement] Room key set automatically to ${roomKey}`);
-        socketRef.current.emit("getPlayersInRoom", { roomKey });
-      }
-    }, [roomKey]);
-
-    // Listen for updated player list from the server
-    useEffect(() => {
-      if (socketRef.current) {
-        console.log("[Client-side Acknowledgement] Listening for updated player list...");
-        socketRef.current.on("playersInRoom", (players) => {
-          setPlayersInRoom(players);  // Update the players in room state
-          console.log("[From Server: Players in room] -", players);
-        });
-      }
-    }, []);
-
-    // Load money amount from localStorage on component mount
-    useEffect(() => {
-      const storedMoney = localStorage.getItem("money");
-      if (storedMoney) {
-        setMoney(Number(storedMoney));
-        console.log("[Client-side Acknowledgement] Loaded money from localStorage.");
-      }
-    }, []);
-
-    // Save money amount to localStorage whenever it updates
-    useEffect(() => {
-      if (money !== null) {
-        localStorage.setItem("money", money);
-      }
-    }, [money]);
-
-    useEffect(() => {
-      if (socketRef.current && socketMessage) {
-        socketRef.current.emit("customMessage", {
-          roomKey: roomKey,
-          displayName: socketDisplayName,
-          message: socketMessage,
-        });
-      }
-    }, [socketMessage]);
-
-    // Ensure the getRooms function is initialized once the socket is ready
-    useEffect(() => {
-      if (socketRef.current) {
-        window.getRooms = () => {
-          socketRef.current.emit("getRooms"); // here we make the actual request for the rooms object from server
-        };
-      } else {
-        window.getRooms = () => {
-          console.log("[Client-side Acknowledgement] Socket is not initialized.");
-        };
-      }
-    }, []);
-
-    useEffect(() => {
-      if (socketRef.current) {
-        window.getPlayersInRoom = () => {
-          console.log(
-            "[Client-side Acknowledgement] Requesting players in the current room..."
-          );
-          socketRef.current.emit("getPlayersInRoom");
-        };
-
-        socketRef.current.on("playersInRoom", (players) => {
-          console.log("[From Server: Players in room] -", players);
-        });
-      }
-    }, []);
-
-    useEffect(() => {
-      if (typeof window !== "undefined") {
-        window.setDisplayName = (name) => {
-          if(name === "" || name === null || name === "null") {
-            console.log("[Client-side Acknowledgement] Display name cannot be empty.");
-            return;
-          }
-
-          setSocketDisplayName(name);
-          socketDisplayNameRef.current = name; // Update ref
-          localStorage.setItem("displayName", name);
-          console.log(
-            `[Client-side Acknowledgement] Display name set to: "${name}"`
-          );
-        };
-
-        window.addPlayerToRoom = (roomKey, displayName) => {
-          if (socketRef.current) {
-            console.log(`[Client-side Acknowledgement] Adding player "${displayName}" to room "${roomKey}"...`);
-            socketRef.current.emit("setPlayersInRoom", {
-              roomKey: roomKey,
-              displayName: displayName,
-            });
-          }
-
-          setPlayersInRoom((prevPlayers) => {
-            return [...prevPlayers, {name: displayName}];
-          });
-
-          localStorage.setItem("players", JSON.stringify(playersInRoom));
-
-          console.log(`[Client-side Acknowledgement] Player "${displayName}" added to room "${roomKey}"`);
-        }
-
-        window.setRoomKey = (key) => {
-          if (socketDisplayNameRef.current) {
-            setRoomKey(key);
-            localStorage.setItem("roomKey", key);
-            console.log(`[Client-side Acknowledgement] Room key set to: ${key}`);
-          } else {
-            console.log(
-              "[Client-side Acknowledgement] Cannot set room key before setting display name."
-            );
-          }
-        };
-
-        window.togglePlayerStatus = (roomKey, displayName) => {
+      window.togglePlayerStatus = (roomKey, displayName) => {
+        if (socketRef.current && roomKey && displayName) {
           console.log(`[Client-side Acknowledgement] Toggling player status for ${displayName} in ${roomKey}`);
-          if (socketRef.current && roomKey && displayName) {
-            console.log(`[Client-side Acknowledgement] Toggling player status for ${displayName} in ${roomKey}`);
-            socketRef.current.emit("player_ready", {
-              roomKey: roomKey,
-              displayName: displayName,
-            });
+          socketRef.current.emit("player_ready", {
+            roomKey: roomKey,
+            displayName: displayName,
+          });
+        }
+      }
+
+      window.setMoneyAmount = (amount) => {
+        if (typeof amount === "number") {
+          setMoney(amount); // Update local money state
+          if (socketRef.current) {
+            socketRef.current.emit("setMoneyAmount", {
+              displayName: localStorage.getItem("displayName"),
+              roomKey: localStorage.getItem("roomKey"),
+              money: amount,
+            }); // Communicate the money amount to the server
           }
         }
+      };
 
-        window.setMoneyAmount = (amount) => {
-          if (typeof amount === "number") {
-            setMoney(amount); // Update local money state
-            if (socketRef.current) {
-              socketRef.current.emit("setMoneyAmount", {
-                displayName: localStorage.getItem("displayName"),
-                roomKey: localStorage.getItem("roomKey"),
-                money: amount,
-              }); // Communicate the money amount to the server
-            }
-          }
-        };
+      window.sendMessage = (msg) => {
+        setSocketMessage(msg);
+        console.log(`[Client-side Acknowledgement] Message sent: "${msg}"`);
+      };
+    }
+  }, []);
 
-        window.sendMessage = (msg) => {
-          setSocketMessage(msg);
-          console.log(`[Client-side Acknowledgement] Message sent: "${msg}"`);
-        };
-      }
-    }, []);
-
-    return socketRef.current;
-  };
+  return socketRef.current;
+};

--- a/client/app/socketClient.js
+++ b/client/app/socketClient.js
@@ -109,8 +109,12 @@
       });
 
       socketInstance.on("playersInRoom", (players) => {
-        setPlayersInRoom(players);
-        console.log("[From Server: Players in room] -", players);
+        const playerList = Object.entries(players).map(([name, attributes]) => ({
+          name,
+          ...attributes,
+      }));
+        setPlayersInRoom(playerList);
+        console.log("[From Server: Players in room] -", playerList);
       });
 
       socketInstance.on("receivedCustomMessage", (message) => {
@@ -266,6 +270,17 @@
             );
           }
         };
+
+        window.togglePlayerStatus = (roomKey, displayName) => {
+          console.log(`[Client-side Acknowledgement] Toggling player status for ${displayName} in ${roomKey}`);
+          if (socketRef.current && roomKey && displayName) {
+            console.log(`[Client-side Acknowledgement] Toggling player status for ${displayName} in ${roomKey}`);
+            socketRef.current.emit("player_ready", {
+              roomKey: roomKey,
+              displayName: displayName,
+            });
+          }
+        }
 
         window.setMoneyAmount = (amount) => {
           if (typeof amount === "number") {

--- a/client/app/waiting-room/[roomid]/page.js
+++ b/client/app/waiting-room/[roomid]/page.js
@@ -150,10 +150,12 @@ const WaitingPage = () => {
           Object.keys(players)
             // .filter(player => players[player].roomKey === roomNumber) // Filter players by the current room number
             .map((player, index) => (
-              <div key={index} className={styles.playerBox}>
+              <div className={styles.playersContainer}>
+              <div key={index} className={styles.playerCircle}>
                 {player} {players[player].status === 'ready' && '(Ready)'}
                 {player === displayName && ' (You)'} {/* Mark the current player with '(You)' */}
-                {players[player].ready ? <div className={styles.readyStatus}>Ready</div> : <div className={""}>Not Ready</div>}
+              </div>
+              {players[player].ready ? <div className={styles.readyStatus}>Ready</div> : <div className={styles.readyStatus}>Not Ready</div>}
               </div>
             ))
         ) : (
@@ -166,7 +168,7 @@ const WaitingPage = () => {
         {readyStatus ? <p className={styles.waitingMessage}>Waiting for other players...</p> : null}
       </div>
 
-      {/* <div className={styles.rulesToggle} onClick={toggleRules}>
+      <div className={styles.rulesToggle} onClick={toggleRules}>
         {showRules ? 'Hide Rules' : 'Show Rules'}
       </div>
 
@@ -185,7 +187,7 @@ const WaitingPage = () => {
           <li className={styles.gameRules}>Final Jeopardy!: All players can wager any amount up to their total score on the final clue.</li>
           <li className={styles.gameRules}>Timing: You have a limited time to buzz in after the clue is read, and then to provide your answer.</li>
         </ul>
-      </div> */}
+      </div>
     </div>
   );
 };

--- a/client/app/waiting-room/waiting-page.module.css
+++ b/client/app/waiting-room/waiting-page.module.css
@@ -84,15 +84,23 @@
 .readyStatusContainer {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
+}
+
+.readyStatus {
+  font-size: 20px;
+  color: #ffcc00;
+  text-align: center;
 }
 
 .animatedLetter {
   display: inline-block; 
   transform: translateX(-50px);
   opacity: 0; 
-  animation: fadeIn 5s forwards; 
+  animation: fadeIn 2.5s forwards; 
   animation-iteration-count: infinite; 
+  animation-fill-mode: both;
 }
 
 @keyframes fadeIn {
@@ -130,13 +138,51 @@
 .readyPlayers {
   margin-top: 30px;
   display: flex;
-  flex-direction: column;
+  /* flex-direction: column; */
+  justify-content: center;
   gap: 20px;
   width: 50%; /* Adjust as needed */
   font-family: 'Impact', sans-serif;
   font-size: 25px;
   color: #ffcc00;
   align-items: center;
+}
+
+.playersContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 10px;
+}
+
+.playerCircle {
+  width: 80px;
+  height: 80px;
+  background-color: #002366;
+  color: #ffd700;
+  border: 2px solid #ffd700;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0 10px;
+  transition: background-color 0.3s ease, transform 0.3s ease;
+  padding: 20px;
+  /* margin-top: 50px; */
+}
+
+.playerCircle:hover {
+  background-color: #ffd700;
+  color: #002366;
+  transform: scale(1.1);
+}
+
+.readyPlayerCircle {
+  background-color: #28a745;
+  color: white;
+  border: 2px solid #28a745;
 }
 
 .playerBox {
@@ -180,6 +226,7 @@
   font-family: 'Impact', sans-serif;
   font-size: 20px;
   margin-top: 70px;
+  z-index: 11;
 }
 
 .readyButtonMarginBottom {

--- a/client/app/waiting-room/waiting-page.module.css
+++ b/client/app/waiting-room/waiting-page.module.css
@@ -81,6 +81,12 @@
   margin-top: 50px;
 }
 
+.readyStatusContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .animatedLetter {
   display: inline-block; 
   transform: translateX(-50px);
@@ -176,6 +182,10 @@
   margin-top: 70px;
 }
 
+.readyButtonMarginBottom {
+  margin-bottom: 48px;
+}
+
 .readyButton::before {
   content: 'Ready';
   color: #fafafa;
@@ -227,6 +237,10 @@
 .rulesToggle:hover {
   color: #f3f4f5;
   text-decoration: underline; 
+}
+
+.waitingMessage {
+  margin-top: 30px;
 }
 
 .gameRules {

--- a/client/app/waiting-room/waiting-page.module.css
+++ b/client/app/waiting-room/waiting-page.module.css
@@ -195,6 +195,7 @@
   transform: translate(-50%, -50%);
   opacity: 0;
   transition: opacity 0.3s ease;
+  pointer-events: none;
 }
 
 .readyButton:hover::before {
@@ -203,7 +204,7 @@
 
 .readyButton:hover {
   color: transparent;
-  background-color: #28a745;
+  background-color: #24943e;
 }
 
 .readyButtonActive {

--- a/server/socketServer.js
+++ b/server/socketServer.js
@@ -85,12 +85,12 @@ function setupSocketServer(server) {
         });
 
         // Event listener for player joining room
-        socket.on("player_joined", ({ roomKey, playerName, playerStatus }) => {
+        socket.on("player_joined", ({ roomKey, playerName }) => {
             if(!rooms[roomKey]) {
                 rooms[roomKey] = {};
             }
             
-            rooms[roomKey][playerName] = 0; // Default money or other initial data
+            rooms[roomKey][playerName] = {money: 0, ready: false}; // Default money/ready status
             io.to(roomKey).emit("players_list", { players: rooms[roomKey] });
         });
 
@@ -103,6 +103,20 @@ function setupSocketServer(server) {
                 
                 // Notify other users in the room   
                 socket.to(roomKey).emit("userLeft", displayName);
+            }
+        });
+
+        // Event listener for toggling player ready status in room
+        socket.on("player_ready", ({ roomKey, displayName }) => {
+            console.log(`Player ${displayName} ready status toggled in room ${roomKey}`);
+            if(rooms[roomKey] && rooms[roomKey][displayName]) {
+                const player = rooms[roomKey][displayName];
+                player.ready = !player.ready;
+                console.log(`Player ${displayName} ready status toggled to ${player.ready}`);
+
+                io.to(roomKey).emit("players_list", { players: rooms[roomKey] });
+            } else {
+                console.log(`Player ${displayName} or room ${roomKey} not found`);
             }
         });
 

--- a/server/socketServer.js
+++ b/server/socketServer.js
@@ -26,7 +26,7 @@ function setupSocketServer(server) {
             console.log(`Display name received: ${currentDisplayName}`);
 
             // Add player to the default room with a starting balance of 0
-            rooms[""][currentDisplayName] = {money: 0, ready: false}; // Default starting money in the default room
+            rooms[""][currentDisplayName] = 0; // Default starting money in the default room
             currentRoomKey = ""; // By default, user is in the default room
 
             console.log(`User "${currentDisplayName}" added to the default room with 0 balance.`);
@@ -60,9 +60,9 @@ function setupSocketServer(server) {
 
             // Add the player to the new room
             if (!rooms[roomKey]) {
-                rooms[roomKey] = {money: 0, ready: false}; // Create the room if it doesn't exist
+                rooms[roomKey] = {}; // Create the room if it doesn't exist
             }
-            rooms[roomKey][currentDisplayName] = {money: 0, ready: false}; // Default money/ready status
+            rooms[roomKey][currentDisplayName] = {}; // Default money/ready status
             socket.join(roomKey); // Join the new room
 
             console.log(`User "${currentDisplayName}" joined room "${roomKey}"`);
@@ -88,7 +88,7 @@ function setupSocketServer(server) {
         socket.on("player_joined", ({ roomKey, playerName }) => {
             console.log("Player joined room called in server:", roomKey, playerName);
             if(!rooms[roomKey]) {
-                rooms[roomKey] = {money: 0, ready: false};
+                rooms[roomKey] = {};
             }
             
             rooms[roomKey][playerName] = {money: 0, ready: false}; // Default money/ready status

--- a/server/socketServer.js
+++ b/server/socketServer.js
@@ -2,7 +2,7 @@ const { Server } = require('socket.io');
 
 let io;
 const rooms = {
-    "": {}, // Default room for users without a room, stores players and their money
+    "": {money: 0, ready: false}, // Default room for users without a room, stores players and their money
 };
 
 function setupSocketServer(server) {
@@ -26,7 +26,7 @@ function setupSocketServer(server) {
             console.log(`Display name received: ${currentDisplayName}`);
 
             // Add player to the default room with a starting balance of 0
-            rooms[""][currentDisplayName] = 0; // Default starting money in the default room
+            rooms[""][currentDisplayName] = {money: 0, ready: false}; // Default starting money in the default room
             currentRoomKey = ""; // By default, user is in the default room
 
             console.log(`User "${currentDisplayName}" added to the default room with 0 balance.`);
@@ -60,7 +60,7 @@ function setupSocketServer(server) {
 
             // Add the player to the new room
             if (!rooms[roomKey]) {
-                rooms[roomKey] = {}; // Create the room if it doesn't exist
+                rooms[roomKey] = {money: 0, ready: false}; // Create the room if it doesn't exist
             }
             rooms[roomKey][currentDisplayName] = {money: 0, ready: false}; // Default money/ready status
             socket.join(roomKey); // Join the new room
@@ -88,7 +88,7 @@ function setupSocketServer(server) {
         socket.on("player_joined", ({ roomKey, playerName }) => {
             console.log("Player joined room called in server:", roomKey, playerName);
             if(!rooms[roomKey]) {
-                rooms[roomKey] = {};
+                rooms[roomKey] = {money: 0, ready: false};
             }
             
             rooms[roomKey][playerName] = {money: 0, ready: false}; // Default money/ready status
@@ -138,7 +138,7 @@ function setupSocketServer(server) {
             // Ensure the displayName and roomKey are valid
             if (displayName && roomKey) {
                 if (!rooms[roomKey]) {
-                    rooms[roomKey] = {}; // Create the room if it doesn't exist
+                    rooms[roomKey] = {money: 0, ready: false}; // Create the room if it doesn't exist
                 }
         
                 if (rooms[roomKey][displayName] !== undefined) {

--- a/server/tests/socketHandler.test.js
+++ b/server/tests/socketHandler.test.js
@@ -31,7 +31,7 @@ describe("Socket.IO server tests", () => {
 
         serverSocket.on("displayName", (displayName) => {
             expect(displayName).toBe("TestUser");
-            expect(rooms[""]["TestUser"]).toBe(0);
+            expect(rooms[""]["TestUser"]).toStrictEqual({money: 0, ready: false});
             done();
         });
     });
@@ -42,7 +42,7 @@ describe("Socket.IO server tests", () => {
 
         serverSocket.on("roomKey", (roomKey) => {
             expect(roomKey).toBe("Room1");
-            expect(rooms["Room1"]["TestUser"]).toBe(0);
+            expect(rooms["Room1"]["TestUser"]).toStrictEqual({money: 0, ready: false});
             done();
         });
     });
@@ -79,7 +79,7 @@ describe("Socket.IO server tests", () => {
             expect(displayName).toBe("TestUser");
             expect(roomKey).toBe("Room1");
             expect(money).toBe(100);
-            expect(rooms["Room1"]["TestUser"]).toBe(100);
+            expect(rooms["Room1"]["TestUser"].money).toBe(100);
             done();
         });
     });

--- a/server/tests/socketHandler.test.js
+++ b/server/tests/socketHandler.test.js
@@ -31,7 +31,7 @@ describe("Socket.IO server tests", () => {
 
         serverSocket.on("displayName", (displayName) => {
             expect(displayName).toBe("TestUser");
-            expect(rooms[""]["TestUser"]).toStrictEqual({money: 0, ready: false});
+            expect(rooms[""]["TestUser"]).toStrictEqual(0);
             done();
         });
     });
@@ -42,7 +42,7 @@ describe("Socket.IO server tests", () => {
 
         serverSocket.on("roomKey", (roomKey) => {
             expect(roomKey).toBe("Room1");
-            expect(rooms["Room1"]["TestUser"]).toStrictEqual({money: 0, ready: false});
+            expect(rooms["Room1"]["TestUser"]).toStrictEqual({});
             done();
         });
     });


### PR DESCRIPTION
# Pull Request

## Description
Ready button toggles ready status for individual users. Users will not be redirected from waiting room until there are more than one user in the room and all users's statuses are ready.

## What's in this change?

- [x] Added event listeners in `socketClient.js` and `socketServer.js` to handle toggling of user status
- [x] Added player status to player info in socket
- [x] Modified ready button to redirect users after everyone in the room is ready

## Testing changes

To test changes before merging:
- Create a room and join and click the ready button which the user's ready status should be reflected with "ready" and "not ready" next to their name
- Open an incognito account and log into another account and join the same room and upon the first account with a ready status, when the second account toggles ready, both users should be brought to the game board