### PR TITLE
Responsive design for smaller screen and horizontal overflow resolved

### DIFF
--- a/client/app/[userid]/[userid].module.css
+++ b/client/app/[userid]/[userid].module.css
@@ -4,12 +4,28 @@
   color: white;
   font-family: sans-serif;
   overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 .main {
   display: flex;
   padding: 1rem;
   gap: 1rem;
+}
+
+@media (max-width: 768px) {
+  .main {
+    flex-direction: column; 
+  }
+
+  .main .howToPlay, 
+  .main .gameInfoContainer {
+    width: 100%;
+  }
+
+  .howToPlay {
+    order: 1;
+  }
 }
 
 .howToPlay {
@@ -37,6 +53,7 @@
 
 .lowerGameInfo {
   display: flex;
+  width: 100%;
   gap: 1rem;
 }
 
@@ -86,7 +103,7 @@
 .createRoomButton,
 .joinRoomButton {
   display: block;
-  width: 200px;
+  /* width: 200px; */
   background-color: #ffcc33;
   color: #001f3f;
   border: none;
@@ -113,6 +130,7 @@
 }
 
 .buttonRow {
+  width: 100%;
   display: flex;
   justify-content: space-between;
   gap: 10px;


### PR DESCRIPTION
# Pull Request

## Description
Horizontal overflow of available rooms is resolved in addition to modified styling for smaller screens (<768px)

## What's in this change?

Outline the specific changes that are being introduced. Use bullet points to break them down where appropriate.

- [x] removed size restriction on buttons in available room container
- [x] added styling to handle smaller screens

Before:
![dashboard-responsive-design-before](https://github.com/user-attachments/assets/4132c78a-b349-4d98-893b-61eadd50e298)

After:
![dashboard-responsive-design-after](https://github.com/user-attachments/assets/cbd5c86a-a8e2-42ed-a49a-b33b014c194d)

## Testing changes
Change the screen size, specifically the width, to make sure everything looks right.
