### PR TITLE
UI Updates for responsive gameboard View

### DIFF
--- a/client/app/game-board/game-board.module.css
+++ b/client/app/game-board/game-board.module.css
@@ -9,42 +9,60 @@
 
 @media (max-width: 768px) {
   .page .button {
-    font-size: 1rem;
+    font-size: 1.25rem;
   }
 
   .page .firstrow {
-    font-size: 0.75rem;
+    font-size: 10px;
+  }
+
+  .page .nextRoundButton {
+    padding: 15px 20px;
   }
 }
 
 .gameBoard {
   width: 80%;
-  height: 100%; 
+  height: 100%;
   display: grid;
   grid-template-rows: repeat(6, 1fr); /* 6 equal rows */
   gap: 10px; 
 }
 
-.playerScores {
+.InfoContainer {
   width: 20%;
   height: auto;
-  flex-grow: 1;
-  flex-shrink: 1;
-  background-color: rgb(7, 18, 119);
-  color: rgb(238, 196, 78);
-  padding: 20px;
   display: flex;
   flex-direction: column;
+  justify-content: space-evenly;
   align-items: center;
+  padding: 20px;
   margin: 10px 12px 10px 8px; /* top right bottom left */
+  background-color: rgb(7, 18, 119);
+  border-radius: 10px;
+}
+
+.playerScores {
+  width: 100%;
+  height: 100%;
+  flex-grow: 1;
+  flex-shrink: 1;
+  color: rgb(238, 196, 78);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
   border-radius: 10px;
 }
 
 .playerScores h2 {
-  font-size: 40px;
+  font-size: 1.5rem;
   text-align: center;
-  margin-top: 40px;
-  margin-bottom: 40px;
+}
+
+.playerScoreContainer {
+  display: flex;
+  flex-direction: column;
 }
 
 .playerScore {
@@ -69,13 +87,14 @@
   margin: 10px;
   color: rgb(238, 196, 78);
   background-color: rgb(7, 18, 119);
-  font-size: 2rem;
+  font-size: 1.5rem;
   display: flex;
   justify-content: center;
   align-items: center;
   border: none;
   cursor: pointer;
   transition: transform 0.3s ease;
+  width: 100%;
 }
 
 .firstbuttonrow,
@@ -87,16 +106,13 @@
 
 .firstrow {
   width: 100%;
-  max-width: 100%;
   margin: 10px;
   color: rgb(255, 255, 255);
   background-color: rgb(7, 18, 119);
-  font-size: 1rem;
   display: flex;
   justify-content: center;
   align-items: center;
   border: none;
-  padding: 15px;
   text-align: center;
   word-wrap: break-word;
   line-height: 1.2;
@@ -265,7 +281,6 @@
 
 .nextRoundButton {
   padding: 15px 30px;
-  margin-top: 1rem;
   font-size: 24px;
   background-color: rgb(238, 196, 78);
   color: rgb(7, 18, 119);

--- a/client/app/game-board/game-board.module.css
+++ b/client/app/game-board/game-board.module.css
@@ -13,7 +13,7 @@
   }
 
   .page .firstrow {
-    font-size: 10px;
+    font-size: 0.75rem;
   }
 
   .page .nextRoundButton {
@@ -84,7 +84,7 @@
 
 .button {
   flex: 1;
-  margin: 10px;
+  margin: 0 5px;
   color: rgb(238, 196, 78);
   background-color: rgb(7, 18, 119);
   font-size: 1.5rem;
@@ -95,18 +95,22 @@
   cursor: pointer;
   transition: transform 0.3s ease;
   width: 100%;
+  height: 95%;
 }
 
 .firstbuttonrow,
 .buttonrow {
   display: flex;
   justify-content: space-evenly;
+  align-items: center;
   width: 100%;
 }
 
 .firstrow {
   width: 100%;
-  margin: 10px;
+  height: 95%;
+  margin: 0 5px;
+  font-size: 1rem;
   color: rgb(255, 255, 255);
   background-color: rgb(7, 18, 119);
   display: flex;

--- a/client/app/game-board/game-board.module.css
+++ b/client/app/game-board/game-board.module.css
@@ -2,23 +2,27 @@
   background-color: rgb(0, 0, 1);
   font-family: "Impact", sans-serif;
   width: 100vw;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
   display: flex;
+}
+
+@media (max-width: 768px) {
+  .page .button {
+    font-size: 1rem;
+  }
+
+  .page .firstrow {
+    font-size: 0.75rem;
+  }
 }
 
 .gameBoard {
   width: 80%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-.boardContent {
-  flex-grow: 1;
+  height: 100%; 
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 10px;
-  padding: 10px;
+  grid-template-rows: repeat(6, 1fr); /* 6 equal rows */
+  gap: 10px; 
 }
 
 .playerScores {
@@ -61,12 +65,11 @@
 }
 
 .button {
-  width: 200px;
-  height: 100px;
+  flex: 1;
   margin: 10px;
   color: rgb(238, 196, 78);
   background-color: rgb(7, 18, 119);
-  font-size: 55px;
+  font-size: 2rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -78,15 +81,17 @@
 .firstbuttonrow,
 .buttonrow {
   display: flex;
+  justify-content: space-evenly;
+  width: 100%;
 }
 
 .firstrow {
-  width: 300px;
-  height: 145px;
+  width: 100%;
+  max-width: 100%;
   margin: 10px;
   color: rgb(255, 255, 255);
   background-color: rgb(7, 18, 119);
-  font-size: 28px;
+  font-size: 1rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -103,6 +108,14 @@
   background-color: rgb(240, 214, 107);
   transform: scale(1.1);
   color: white;
+}
+
+.buttonValue {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .modal {

--- a/client/app/game-board/page.js
+++ b/client/app/game-board/page.js
@@ -518,7 +518,7 @@ export default function GameBoardPage() {
 
     return roundInfo.map((category, index) => (
       <button className={styles.firstrow} key={index}>
-        {category.category}
+        <span className={styles.buttonValue}>{category.category}</span>
       </button>
     ));
   }, [roundInfo]);
@@ -566,7 +566,7 @@ export default function GameBoardPage() {
       }
     }
 
-    // Create rows
+    // Create rows using grid structure
     for (let rowIndex = 0; rowIndex < maxValues; rowIndex++) {
       const buttonRow = (
         <div className={styles.buttonrow} key={rowIndex}>
@@ -616,7 +616,7 @@ export default function GameBoardPage() {
                   fetchQuestion(category, value);
                 }}
               >
-                {value || ""}
+                <span className={`${styles.buttonValue}`}>{value || ""}</span>
               </button>
             );
           })}
@@ -945,13 +945,6 @@ export default function GameBoardPage() {
           {clueAnswerNotification}
         </div>
       )}
-      <div>
-        {!selectedQuestion && (
-          <button onClick={nextRound} className={styles.nextRoundButton}>
-            {round === "Final Jeopardy!" ? "End Game" : "Next Round!"}
-          </button>
-        )}
-      </div>
     </div>
   );
 }

--- a/client/app/game-board/page.js
+++ b/client/app/game-board/page.js
@@ -787,24 +787,28 @@ export default function GameBoardPage() {
         <div className={styles.firstbuttonrow}>{renderCategories()}</div>
         {renderRows()}
       </div>
-      <div className={styles.playerScores}>
-        <h2>Player Scores</h2>
-        {Object.entries(playerScores).map(([player, score]) => (
-          <div key={player} className={styles.playerScore}>
-            {player}: {score.money}
+      <div className={styles.InfoContainer}>
+        <div className={styles.playerScores}>
+          <div className={styles.playerScoreContainer}>
+            <h2>Player Scores</h2>
+            {Object.entries(playerScores).map(([player, score]) => (
+              <div key={player} className={styles.playerScore}>
+                {player}: {score.money}
+              </div>
+            ))}
           </div>
-        ))}
-        <div className={styles.playerSelectingNext}>
-          <h2>Player Selecting Next:</h2>
-          <p>{lastPlayerCorrect}</p>
+          <div className={styles.playerScoreContainer}>
+            <div className={styles.playerSelectingNext}>
+              <h2>Player Selecting Next:</h2>
+              <p>{lastPlayerCorrect}</p>
+            </div>
+          </div>
         </div>
-        <div className={styles.nextRoundButtonContainer}>
-          {!selectedQuestion && (
+        {!selectedQuestion && (
             <button onClick={nextRound} className={styles.nextRoundButton}>
               {round === "Final Jeopardy!" ? "End Game" : "Next Round!"}
             </button>
           )}
-        </div>
       </div>
       {expandingBox && (
         <div


### PR DESCRIPTION
# Pull Request

## Description
Gameboard styling with grid for equal spacing relative to screen. *Note:* Any smaller mobile screens (< 768 in width) cause the gameboard to overflow its container and overlap with the player scores.

Before: 
![grid-gameboard-768px-before](https://github.com/user-attachments/assets/22da305a-52f7-48da-a348-fb26dec8ed1f)

After:
![grid-gameboard-768px-after](https://github.com/user-attachments/assets/640e3649-83c3-47f2-9d1a-16d4d36b45a4)

## What's in this change?

- [X] Updated styling for gameboard for 768 px and above

## Testing changes

Describe how the changes were tested. If possible, include:
Test with inspector screen sizes of Laptop and above