### PR TITLE
fixing wss issue

### DIFF
--- a/client/app/game-board/page.js
+++ b/client/app/game-board/page.js
@@ -30,7 +30,7 @@ export default function GameBoardPage() {
   const [clueAnswerNotification, setClueAnswerNotification] = useState(null);
   const questionRef = useRef(null);
   const router = useRouter();
-  const signalingServerUrl = process.env.NEXT_PUBLIC_SERVER_URL.replace(/^https/, 'ws');
+  const signalingServerUrl = "wss://team2-server-pr-207.onrender.com";
   
   // Load completeRoomInfo from localStorage on component mount
   useEffect(() => {

--- a/server/voiceChatServer.js
+++ b/server/voiceChatServer.js
@@ -4,17 +4,12 @@ let wss;
 let clients = [];
 
 function setupWebRTCSocketServer() {
-  // Create a WebSocket server on a separate port or on the same server.
-  // For simplicity, we assume it's on port 8081. Adjust as needed.
   wss = new WebSocket.Server({ port: 8081 });
 
   wss.on('connection', (ws) => {
     clients.push(ws);
     const clientId = clients.indexOf(ws);
 
-    // Send initial info message so the client knows if it should be initiator
-    // For simplicity: the first client connected will be the initiator.
-    // All subsequent clients are responders.
     const isInitiator = clientId === 0;
     ws.send(JSON.stringify({ type: 'info', initiator: isInitiator }));
 
@@ -27,8 +22,6 @@ function setupWebRTCSocketServer() {
         return;
       }
 
-      // Broadcast this signaling message to all other connected clients
-      // except the sender
       clients.forEach((client, index) => {
         if (client !== ws && client.readyState === WebSocket.OPEN) {
           client.send(JSON.stringify(parsed));


### PR DESCRIPTION
# Pull Request

## Description

Implemented voice chat on the game board.

## What's in this change?

- voice chat added, players are automatically connected once they reach the game board, but they have to set status first. to set status, they must set the role variable in local storage to either initiator or responder

## Testing changes

tested locally. unfortunately with features like this, there has to be testing in deployment as well, to make sure local things work in deployment. we had issues last time with sockets in deployment and it took several deployments to get it all working.

note: this time we are testing with the specific PR deployment link to make sure it works